### PR TITLE
:bug: add viewsWelcome transform to prebuild branding script

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -97,6 +97,27 @@ function replaceBrandWord(str) {
   return str.replace(/\bKonveyor\b/g, shortName);
 }
 
+/** Replace brand references in viewsWelcome contents (markdown with embedded command URIs) */
+function replaceWelcomeContents(str) {
+  let result = str;
+  // Replace publisher-qualified extension IDs (e.g., konveyor.konveyor → redhat.mta-vscode-extension)
+  for (const [from, to] of Object.entries(NAME_MAP)) {
+    result = result.replaceAll(`konveyor.${from}`, `${publisher}.${to}`);
+  }
+  // Replace URL-encoded publisher search queries
+  result = result.replaceAll("%40publisher%3Akonveyor", `%40publisher%3A${publisher}`);
+  // Replace hyphenated name prefixes (e.g., konveyor-core. → mta-core.)
+  // Skip plain "konveyor" to avoid breaking URLs like konveyor.io
+  for (const [from, to] of Object.entries(NAME_MAP)) {
+    if (from.includes("-")) {
+      result = result.replaceAll(`${from}.`, `${to}.`);
+    }
+  }
+  // Replace brand word (Konveyor → MTA)
+  result = replaceBrandWord(result);
+  return result;
+}
+
 function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -215,6 +236,16 @@ function brandCoreExtension(pkg) {
       ...submenu,
       id: replaceSubmenuId(submenu.id),
       label: `${shortName} Actions`,
+    }));
+  }
+
+  // Transform viewsWelcome
+  if (pkg.contributes?.viewsWelcome) {
+    pkg.contributes.viewsWelcome = pkg.contributes.viewsWelcome.map((entry) => ({
+      ...entry,
+      view: replacePrefix(entry.view),
+      when: entry.when ? replaceWhenClause(entry.when) : entry.when,
+      contents: entry.contents ? replaceWelcomeContents(entry.contents) : entry.contents,
     }));
   }
 


### PR DESCRIPTION
## Summary
- The prebuild branding script transforms commands, views, menus, config keys, and submenus — but was missing `viewsWelcome`
- After rebranding, the `viewsWelcome` entries still referenced `konveyor-core.issueView` and embedded `command:konveyor-core.*` URIs
- Installing both upstream (Konveyor) and downstream (MTA) extensions caused the welcome content to render twice in the upstream view because the MTA welcome entries targeted the Konveyor view ID

### Changes
- Add `replaceWelcomeContents()` helper to handle markdown contents with embedded command URIs, publisher-qualified extension IDs, URL-encoded publisher search queries, and brand words
- Add `viewsWelcome` transform block to `brandCoreExtension()` that transforms `view` refs, `when` clauses, and `contents` using the same patterns as existing command/menu/view transforms

## Test plan
- [ ] Run `node scripts/prebuild.js` and inspect `vscode/core/package.json` viewsWelcome entries
- [ ] Verify `view` fields changed from `konveyor-core.issueView` to `mta-core.issueView`
- [ ] Verify `when` clauses changed from `konveyor-core.hasProviders` to `mta-core.hasProviders`
- [ ] Verify `contents` command URIs changed from `command:konveyor-core.*` to `command:mta-core.*`
- [ ] Verify `contents` brand word changed from `Konveyor` to `MTA`
- [ ] Verify `konveyor.io` URLs are preserved (not transformed)
- [ ] Build and install MTA VSIX alongside Konveyor dev extension — no duplicate welcome views


Made with [Cursor](https://cursor.com)