### PR TITLE
:seedling: switch fallbackAssetsUrl to 8.2.0

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -17,8 +17,7 @@ export const shortName = "MTA";
 export const repositoryUrl = "https://github.com/migtools/editor-extensions";
 export const bugsUrl = "https://github.com/migtools/editor-extensions/issues";
 export const homepageUrl = "https://developers.redhat.com/products/mta/overview";
-// TODO: Switch to 8.2.0 when assets are published
-export const fallbackAssetsUrl = "https://developers.redhat.com/content-gateway/rest/browse/pub/mta/8.1.0/"
+export const fallbackAssetsUrl = "https://developers.redhat.com/content-gateway/rest/browse/pub/mta/8.2.0/"
 
 // ─── PRE-RELEASE ASSET HANDLING (uncomment for next pre-release cycle) ──────
 // To use candidate/internal assets during pre-release, uncomment the following


### PR DESCRIPTION
The MTA 8.2.0 analyzer-rpc binaries are now published on the Red Hat CDN.

Switch the `fallbackAssetsUrl` from the temporary 8.1.0 placeholder to the correct 8.2.0 URL:
```
https://developers.redhat.com/content-gateway/rest/browse/pub/mta/8.2.0/
```

Once CI passes on this PR and it merges, we can tag `v8.2.0` for the release.